### PR TITLE
[Core] Add input action support to Controller and add example minigame

### DIFF
--- a/Core/Controls/player_select_screen.gd
+++ b/Core/Controls/player_select_screen.gd
@@ -1,4 +1,7 @@
-extends HBoxContainer
+class_name PlayerSelectScreen
+extends VBoxContainer
+
+signal pressed_start
 
 @onready var _selected_labels: Array[Label] = [
 	%Player1/Selected,
@@ -6,6 +9,7 @@ extends HBoxContainer
 	%Player3/Selected,
 	%Player4/Selected
 ]
+@onready var _start_game_label: Label = %StartGameLabel
 
 
 func _ready() -> void:
@@ -13,7 +17,11 @@ func _ready() -> void:
 
 
 func _process(_delta: float) -> void:
-	_update_selected_labels()
+	_update_labels()
+	
+	for player in range(Controls.Player.ONE, Controls.Player.size()):
+		if Controls.is_action_just_pressed(player, "core_submit"):
+			pressed_start.emit()
 
 
 func _input(event: InputEvent) -> void:
@@ -30,8 +38,10 @@ func _input(event: InputEvent) -> void:
 			Controls.try_assign_player_controller(player, event.device)
 
 
-func _update_selected_labels() -> void:
-	for player in range(Controls.Player.ONE, Controls.Player.COUNT):
+func _update_labels() -> void:
+	for player in range(Controls.Player.ONE, Controls.Player.size()):
 		var selected := Controls.get_controller_of_player(player) != -1
 		
 		_selected_labels[player].text = "Selected" if selected else ""
+	
+	_start_game_label.visible = Controls.get_assigned_player_count() == Controls.Player.size()

--- a/Core/Controls/player_select_screen.tscn
+++ b/Core/Controls/player_select_screen.tscn
@@ -6,7 +6,7 @@
 [ext_resource type="Texture2D" uid="uid://cxyrgedx3jbr8" path="res://Core/Controls/Assets/button_color_x_outline.svg" id="3_x7sbj"]
 [ext_resource type="Texture2D" uid="uid://bjbssi8a005j8" path="res://Core/Controls/Assets/button_color_y_outline.svg" id="4_ode0b"]
 
-[node name="PlayerSelectScreen" type="HBoxContainer"]
+[node name="PlayerSelectScreen" type="VBoxContainer"]
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -16,82 +16,93 @@ theme_override_constants/separation = 64
 alignment = 1
 script = ExtResource("1_81omw")
 
-[node name="Player1" type="VBoxContainer" parent="."]
+[node name="HBoxContainer" type="HBoxContainer" parent="."]
+layout_mode = 2
+theme_override_constants/separation = 64
+alignment = 1
+
+[node name="Player1" type="VBoxContainer" parent="HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 alignment = 1
 
-[node name="Label" type="Label" parent="Player1"]
+[node name="Label" type="Label" parent="HBoxContainer/Player1"]
 layout_mode = 2
 text = "Player 1"
 horizontal_alignment = 1
 
-[node name="TextureRect" type="TextureRect" parent="Player1"]
+[node name="TextureRect" type="TextureRect" parent="HBoxContainer/Player1"]
 layout_mode = 2
 texture = ExtResource("1_g240e")
 stretch_mode = 3
 
-[node name="Selected" type="Label" parent="Player1"]
+[node name="Selected" type="Label" parent="HBoxContainer/Player1"]
 layout_mode = 2
 text = "Selected"
 horizontal_alignment = 1
 
-[node name="Player2" type="VBoxContainer" parent="."]
+[node name="Player2" type="VBoxContainer" parent="HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 alignment = 1
 
-[node name="Label" type="Label" parent="Player2"]
+[node name="Label" type="Label" parent="HBoxContainer/Player2"]
 layout_mode = 2
 text = "Player 2"
 horizontal_alignment = 1
 
-[node name="TextureRect" type="TextureRect" parent="Player2"]
+[node name="TextureRect" type="TextureRect" parent="HBoxContainer/Player2"]
 layout_mode = 2
 texture = ExtResource("2_au23s")
 stretch_mode = 3
 
-[node name="Selected" type="Label" parent="Player2"]
+[node name="Selected" type="Label" parent="HBoxContainer/Player2"]
 layout_mode = 2
 text = "Selected"
 horizontal_alignment = 1
 
-[node name="Player3" type="VBoxContainer" parent="."]
+[node name="Player3" type="VBoxContainer" parent="HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 alignment = 1
 
-[node name="Label" type="Label" parent="Player3"]
+[node name="Label" type="Label" parent="HBoxContainer/Player3"]
 layout_mode = 2
 text = "Player 3"
 horizontal_alignment = 1
 
-[node name="TextureRect" type="TextureRect" parent="Player3"]
+[node name="TextureRect" type="TextureRect" parent="HBoxContainer/Player3"]
 layout_mode = 2
 texture = ExtResource("3_x7sbj")
 stretch_mode = 3
 
-[node name="Selected" type="Label" parent="Player3"]
+[node name="Selected" type="Label" parent="HBoxContainer/Player3"]
 layout_mode = 2
 text = "Selected"
 horizontal_alignment = 1
 
-[node name="Player4" type="VBoxContainer" parent="."]
+[node name="Player4" type="VBoxContainer" parent="HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 alignment = 1
 
-[node name="Label" type="Label" parent="Player4"]
+[node name="Label" type="Label" parent="HBoxContainer/Player4"]
 layout_mode = 2
 text = "Player 4"
 horizontal_alignment = 1
 
-[node name="TextureRect" type="TextureRect" parent="Player4"]
+[node name="TextureRect" type="TextureRect" parent="HBoxContainer/Player4"]
 layout_mode = 2
 texture = ExtResource("4_ode0b")
 stretch_mode = 3
 
-[node name="Selected" type="Label" parent="Player4"]
+[node name="Selected" type="Label" parent="HBoxContainer/Player4"]
 layout_mode = 2
 text = "Selected"
+horizontal_alignment = 1
+
+[node name="StartGameLabel" type="Label" parent="."]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Press START to play the game!"
 horizontal_alignment = 1

--- a/Core/Main/main.gd
+++ b/Core/Main/main.gd
@@ -1,0 +1,54 @@
+extends Node
+
+@onready var _player_select_screen_scene: PackedScene = load("res://Core/Controls/player_select_screen.tscn")
+
+@onready var _all_minigames: Array[Minigame] = get_all_minigames()
+
+var _player_select_screen: PlayerSelectScreen = null
+var _current_minigame: Minigame = null
+var _current_minigame_scene: Node = null
+
+
+func _ready() -> void:
+	open_player_select_screen()
+
+
+func _on_player_select_screen_start_pressed() -> void:
+	if _player_select_screen != null:
+		_player_select_screen.queue_free()
+		_player_select_screen = null
+		
+		# TODO: Open game board instead
+		if _all_minigames.size() > 0:
+			_current_minigame = _all_minigames[0]
+			_current_minigame_scene = _current_minigame.scene.instantiate()
+			add_child(_current_minigame_scene)
+
+
+func get_all_minigames() -> Array[Minigame]:
+	var dir = DirAccess.open("res://Core/Minigames")
+	
+	if not dir:
+		return []
+	
+	var minigames: Array[Minigame] = []
+	
+	dir.list_dir_begin()
+	var file_name = dir.get_next()
+	while file_name != "":
+		if file_name.get_extension() == "tres":
+			var resource = ResourceLoader.load("res://Core/Minigames/" + file_name)
+			if resource is Minigame:
+				minigames.append(resource)
+		file_name = dir.get_next()
+	
+	return minigames
+
+
+func open_player_select_screen() -> void:
+	if _player_select_screen != null:
+		return
+	
+	_player_select_screen = _player_select_screen_scene.instantiate()
+	add_child(_player_select_screen)
+	_player_select_screen.pressed_start.connect(_on_player_select_screen_start_pressed)

--- a/Core/Main/main.tscn
+++ b/Core/Main/main.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3 uid="uid://dhuu5bu774ywi"]
+
+[ext_resource type="Script" path="res://Core/Main/main.gd" id="1_ri46c"]
+
+[node name="Main" type="Node"]
+script = ExtResource("1_ri46c")

--- a/Core/Minigames/example_minigame.tres
+++ b/Core/Minigames/example_minigame.tres
@@ -1,0 +1,10 @@
+[gd_resource type="Resource" script_class="Minigame" load_steps=3 format=3 uid="uid://du4dg67vgfyg8"]
+
+[ext_resource type="Script" path="res://Core/Minigames/minigame.gd" id="1_2rveh"]
+[ext_resource type="PackedScene" uid="uid://bxdxdtb7hygle" path="res://ExampleMinigame/example_minigame.tscn" id="1_alhig"]
+
+[resource]
+script = ExtResource("1_2rveh")
+name = "Example Minigame"
+description = ""
+scene = ExtResource("1_alhig")

--- a/Core/Minigames/minigame.gd
+++ b/Core/Minigames/minigame.gd
@@ -1,0 +1,6 @@
+class_name Minigame
+extends Resource
+
+@export var name: String
+@export var description: String
+@export var scene: PackedScene

--- a/ExampleMinigame/example_minigame.tscn
+++ b/ExampleMinigame/example_minigame.tscn
@@ -1,0 +1,57 @@
+[gd_scene load_steps=7 format=3 uid="uid://bxdxdtb7hygle"]
+
+[ext_resource type="PackedScene" uid="uid://do26dwfxfgvfy" path="res://ExampleMinigame/player.tscn" id="1_4panx"]
+
+[sub_resource type="ProceduralSkyMaterial" id="ProceduralSkyMaterial_m7ldj"]
+
+[sub_resource type="Sky" id="Sky_hrp2f"]
+sky_material = SubResource("ProceduralSkyMaterial_m7ldj")
+
+[sub_resource type="Environment" id="Environment_cvidf"]
+background_mode = 2
+sky = SubResource("Sky_hrp2f")
+
+[sub_resource type="PlaneMesh" id="PlaneMesh_x1xr1"]
+size = Vector2(25, 25)
+
+[sub_resource type="ConcavePolygonShape3D" id="ConcavePolygonShape3D_dy1n2"]
+data = PackedVector3Array(12.5, 0, 12.5, -12.5, 0, 12.5, 12.5, 0, -12.5, -12.5, 0, 12.5, -12.5, 0, -12.5, 12.5, 0, -12.5)
+
+[node name="ExampleMinigame" type="Node3D"]
+
+[node name="WorldEnvironment" type="WorldEnvironment" parent="."]
+environment = SubResource("Environment_cvidf")
+
+[node name="DirectionalLight3D" type="DirectionalLight3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 0, 6, 0)
+shadow_enabled = true
+
+[node name="Camera3D" type="Camera3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 0.706279, 0.707933, 0, -0.707933, 0.706279, 0, 12.7409, 15.7514)
+
+[node name="Floor" type="StaticBody3D" parent="."]
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="Floor"]
+mesh = SubResource("PlaneMesh_x1xr1")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Floor"]
+shape = SubResource("ConcavePolygonShape3D_dy1n2")
+
+[node name="Player1" parent="." instance=ExtResource("1_4panx")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -5.93707, 1.51129, 0)
+color = Color(0, 1, 0, 1)
+
+[node name="Player2" parent="." instance=ExtResource("1_4panx")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -2.93707, 1.51129, 0)
+player = 1
+color = Color(1, 0, 0, 1)
+
+[node name="Player3" parent="." instance=ExtResource("1_4panx")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 2.18762, 1.51129, 0)
+player = 2
+color = Color(0, 0.0499997, 1, 1)
+
+[node name="Player4" parent="." instance=ExtResource("1_4panx")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 5.59104, 1.51129, 0)
+player = 3
+color = Color(1, 0.933333, 0, 1)

--- a/ExampleMinigame/player.gd
+++ b/ExampleMinigame/player.gd
@@ -1,0 +1,38 @@
+extends CharacterBody3D
+
+
+const SPEED = 5.0
+const JUMP_VELOCITY = 4.5
+
+
+@export var player: Controls.Player
+@export var color: Color
+
+
+func _ready() -> void:
+	var material = $MeshInstance3D.get_surface_override_material(0)
+	if material is StandardMaterial3D:
+		material.albedo_color = color
+
+
+func _physics_process(delta):
+	# Add the gravity.
+	if not is_on_floor():
+		velocity += get_gravity() * delta
+
+	# Handle jump.
+	if Controls.is_action_just_pressed(player, "core_player_jump") and is_on_floor():
+		velocity.y = JUMP_VELOCITY
+
+	# Get the input direction and handle the movement/deceleration.
+	# As good practice, you should replace UI actions with custom gameplay actions.
+	var input_dir = Controls.get_vector(player, "core_player_left", "core_player_right", "core_player_up", "core_player_down")
+	var direction = (transform.basis * Vector3(input_dir.x, 0, input_dir.y)).normalized()
+	if direction:
+		velocity.x = direction.x * SPEED
+		velocity.z = direction.z * SPEED
+	else:
+		velocity.x = move_toward(velocity.x, 0, SPEED)
+		velocity.z = move_toward(velocity.z, 0, SPEED)
+
+	move_and_slide()

--- a/ExampleMinigame/player.tscn
+++ b/ExampleMinigame/player.tscn
@@ -1,0 +1,21 @@
+[gd_scene load_steps=5 format=3 uid="uid://do26dwfxfgvfy"]
+
+[ext_resource type="Script" path="res://ExampleMinigame/player.gd" id="1_3oash"]
+
+[sub_resource type="CapsuleMesh" id="CapsuleMesh_8mnms"]
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_x2t1w"]
+resource_local_to_scene = true
+albedo_color = Color(1, 0, 0, 1)
+
+[sub_resource type="CapsuleShape3D" id="CapsuleShape3D_t265p"]
+
+[node name="Player" type="CharacterBody3D"]
+script = ExtResource("1_3oash")
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="."]
+mesh = SubResource("CapsuleMesh_8mnms")
+surface_material_override/0 = SubResource("StandardMaterial3D_x2t1w")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="."]
+shape = SubResource("CapsuleShape3D_t265p")

--- a/project.godot
+++ b/project.godot
@@ -22,3 +22,31 @@ Controls="*res://Core/Controls/controls.gd"
 [display]
 
 window/stretch/mode="canvas_items"
+
+[input]
+
+core_player_up={
+"deadzone": 0.5,
+"events": [Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":1,"axis_value":-1.0,"script":null)
+]
+}
+core_player_down={
+"deadzone": 0.5,
+"events": [Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":1,"axis_value":1.0,"script":null)
+]
+}
+core_player_left={
+"deadzone": 0.5,
+"events": [Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":0,"axis_value":-1.0,"script":null)
+]
+}
+core_player_right={
+"deadzone": 0.5,
+"events": [Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":0,"axis_value":1.0,"script":null)
+]
+}
+core_player_jump={
+"deadzone": 0.5,
+"events": [Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":0,"pressure":0.0,"pressed":false,"script":null)
+]
+}

--- a/project.godot
+++ b/project.godot
@@ -11,7 +11,7 @@ config_version=5
 [application]
 
 config/name="Party Game"
-run/main_scene="res://Core/Controls/player_select_screen.tscn"
+run/main_scene="res://Core/Main/main.tscn"
 config/features=PackedStringArray("4.3", "Forward Plus")
 config/icon="res://icon.svg"
 
@@ -48,5 +48,10 @@ core_player_right={
 core_player_jump={
 "deadzone": 0.5,
 "events": [Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":0,"pressure":0.0,"pressed":false,"script":null)
+]
+}
+core_submit={
+"deadzone": 0.5,
+"events": [Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":6,"pressure":0.0,"pressed":false,"script":null)
 ]
 }


### PR DESCRIPTION
This PR adds functions to `Controller` that can query input actions and provides an example minigame that shows how to do simple player movement using the `Controller` interface.