### PR TITLE
[Core] Keyboard debug controls

### DIFF
--- a/Core/Controls/controls.gd
+++ b/Core/Controls/controls.gd
@@ -36,9 +36,6 @@ func _physics_process(_delta: float) -> void:
 	
 	for player in range(Player.ONE, Player.size()):
 		_immediate_player_actions_buffer[player].clear()
-	
-	if is_action_just_pressed(Player.ONE, "core_player_jump"):
-		print("Jumped")
 
 
 func _input(event: InputEvent) -> void:

--- a/Core/Controls/controls.gd
+++ b/Core/Controls/controls.gd
@@ -36,6 +36,9 @@ func _physics_process(_delta: float) -> void:
 	
 	for player in range(Player.ONE, Player.size()):
 		_immediate_player_actions_buffer[player].clear()
+	
+	if is_action_just_pressed(Player.ONE, "core_player_jump"):
+		print("Jumped")
 
 
 func _input(event: InputEvent) -> void:
@@ -43,6 +46,10 @@ func _input(event: InputEvent) -> void:
 		return
 	
 	var player = _player_controllers.find_key(event.device)
+	
+	if event is InputEventKey:
+		player = Player.ONE
+	
 	if player != null:
 		for action: StringName in InputMap.get_actions():
 			if event.is_action_pressed(action):

--- a/project.godot
+++ b/project.godot
@@ -29,31 +29,37 @@ window/stretch/mode="canvas_items"
 core_player_up={
 "deadzone": 0.5,
 "events": [Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":1,"axis_value":-1.0,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":87,"key_label":0,"unicode":119,"location":0,"echo":false,"script":null)
 ]
 }
 core_player_down={
 "deadzone": 0.5,
 "events": [Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":1,"axis_value":1.0,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":83,"key_label":0,"unicode":115,"location":0,"echo":false,"script":null)
 ]
 }
 core_player_left={
 "deadzone": 0.5,
 "events": [Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":0,"axis_value":-1.0,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":65,"key_label":0,"unicode":97,"location":0,"echo":false,"script":null)
 ]
 }
 core_player_right={
 "deadzone": 0.5,
 "events": [Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":0,"axis_value":1.0,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":true,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":68,"key_label":0,"unicode":68,"location":0,"echo":false,"script":null)
 ]
 }
 core_player_jump={
 "deadzone": 0.5,
 "events": [Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":0,"pressure":0.0,"pressed":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":32,"key_label":0,"unicode":32,"location":0,"echo":false,"script":null)
 ]
 }
 core_submit={
 "deadzone": 0.5,
 "events": [Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":6,"pressure":0.0,"pressed":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194309,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 ]
 }
 core_debug_console={


### PR DESCRIPTION
This PR adds basic keyboard debug controls for Player 1 to allow for testing without a controller.

For core input actions, the inputs set are:
- `WASD` for movement
- `Space` for jump
- `Enter` for submit

To add keyboard debug controls to any of your minigame's specific inputs, simply add the keyboard button as an alternative button for an action.
<img width="431" alt="image" src="https://github.com/user-attachments/assets/ced80c8f-b1a1-473e-ae05-c0ab62bc65e8">
