### PR TITLE
[Core] Add debug minigame select screen

### DIFF
--- a/Core/Main/main.gd
+++ b/Core/Main/main.gd
@@ -1,10 +1,13 @@
+class_name Main
 extends Node
 
 @onready var _player_select_screen_scene: PackedScene = load("res://Core/Controls/player_select_screen.tscn")
+@onready var _debug_select_screen_scene: PackedScene = load("res://Core/Minigames/DebugSelectScreen/debug_select_screen.tscn")
 
 @onready var _all_minigames: Array[Minigame] = get_all_minigames()
 
 var _player_select_screen: PlayerSelectScreen = null
+var _debug_select_screen: DebugSelectScreen = null
 var _current_minigame: Minigame = null
 var _current_minigame_scene: Node = null
 
@@ -18,11 +21,20 @@ func _on_player_select_screen_start_pressed() -> void:
 		_player_select_screen.queue_free()
 		_player_select_screen = null
 		
-		# TODO: Open game board instead
-		if _all_minigames.size() > 0:
-			_current_minigame = _all_minigames[0]
-			_current_minigame_scene = _current_minigame.scene.instantiate()
-			add_child(_current_minigame_scene)
+		_debug_select_screen = _debug_select_screen_scene.instantiate()
+		add_child(_debug_select_screen)
+		_debug_select_screen.initialize(_all_minigames)
+		_debug_select_screen.load_minigame.connect(_on_debug_select_screen_load_minigame)
+
+
+func _on_debug_select_screen_load_minigame(minigame: Minigame) -> void:
+	if _debug_select_screen != null:
+		_debug_select_screen.queue_free()
+		_debug_select_screen = null
+		
+		_current_minigame = minigame
+		_current_minigame_scene = minigame.scene.instantiate()
+		add_child(_current_minigame_scene)
 
 
 func get_all_minigames() -> Array[Minigame]:

--- a/Core/Minigames/DebugSelectScreen/debug_select_screen.gd
+++ b/Core/Minigames/DebugSelectScreen/debug_select_screen.gd
@@ -1,0 +1,17 @@
+class_name DebugSelectScreen
+extends Control
+
+
+signal load_minigame(minigame: Minigame)
+
+
+func initialize(minigames: Array[Minigame]) -> void:
+	for minigame in minigames:
+		var button = Button.new()
+		add_child(button)
+		button.text = minigame.name
+		button.pressed.connect(_on_button_pressed.bind(minigame))
+
+
+func _on_button_pressed(minigame: Minigame):
+	load_minigame.emit(minigame)

--- a/Core/Minigames/DebugSelectScreen/debug_select_screen.tscn
+++ b/Core/Minigames/DebugSelectScreen/debug_select_screen.tscn
@@ -1,0 +1,24 @@
+[gd_scene load_steps=2 format=3 uid="uid://2hwem2y0sme7"]
+
+[ext_resource type="Script" path="res://Core/Minigames/DebugSelectScreen/debug_select_screen.gd" id="1_tt6gj"]
+
+[node name="DebugSelectScreen" type="VBoxContainer"]
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -90.5
+offset_top = -17.5
+offset_right = 90.5
+offset_bottom = 17.5
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/separation = 16
+script = ExtResource("1_tt6gj")
+
+[node name="Label" type="Label" parent="."]
+layout_mode = 2
+theme_override_font_sizes/font_size = 32
+text = "Debug Minigame Select"
+horizontal_alignment = 1


### PR DESCRIPTION
This PR adds a debug minigame select screen that appears after the the player select screen. To load a minigame, simply click on one of the minigames with a mouse. This doesn't support controllers and likely never will.

Minigames are added to the debug screen using the minigame resources files located [here](https://github.com/devlup-fsu/party-game/tree/main/Core/Minigames).

<img width="579" alt="image" src="https://github.com/user-attachments/assets/4add7400-43c7-41ab-8f96-e6dd7ad52922">